### PR TITLE
Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.html linguist-detectable=false
+*.html linguist-documentation=false
+
+*.css linguist-detectable=false
+*.css linguist-documentation=false


### PR DESCRIPTION
Hi,

I didn't do any fantastic job. **Html** files are very large and when counted, they take up more of the language of use.

With **linguist** from Github, we can say count what kind of files, or do not count these files. What I did is just add **HTML** and **CSS** files in Linguist to stop counting them.

No, in **most used languages** there is just **Javascript**.

Hope you like it.
May the force be with you.

Amir.